### PR TITLE
feat: better jdownloader integration

### DIFF
--- a/cyberdrop_dl/managers/progress_manager.py
+++ b/cyberdrop_dl/managers/progress_manager.py
@@ -88,6 +88,9 @@ class ProgressManager:
 
         scrape_failures = await self.scrape_stats_progress.return_totals()
         await log_with_color("\nScrape Failures:", "cyan", 20)
+        await log_with_color(f"Unsupported URLs, Sent to Jdownloader: {self.scrape_stats_progress.sent_to_jdownloader}", "yellow", 20)
+        await log_with_color(f"Unsupported URLs, Skipped: {self.scrape_stats_progress.unsupported_urls_skipped}", "yellow", 20)
+        await log_with_color(f"Unsupported URLs, Total: {self.scrape_stats_progress.unsupported_urls}", "yellow", 20)
         for key, value in scrape_failures.items():
             await log_with_color(f"Scrape Failures ({key}): {value}", "red", 20)
 

--- a/cyberdrop_dl/scraper/jdownloader.py
+++ b/cyberdrop_dl/scraper/jdownloader.py
@@ -5,6 +5,7 @@ from dataclasses import field
 from typing import TYPE_CHECKING
 
 from myjdapi import myjdapi
+from pathlib import Path
 
 from cyberdrop_dl.clients.errors import JDownloaderFailure
 from cyberdrop_dl.managers.manager import Manager
@@ -22,28 +23,33 @@ class JDownloader:
         self.jdownloader_device = manager.config_manager.authentication_data['JDownloader']['jdownloader_device']
         self.jdownloader_username = manager.config_manager.authentication_data['JDownloader']['jdownloader_username']
         self.jdownloader_password = manager.config_manager.authentication_data['JDownloader']['jdownloader_password']
-        self.download_directory = manager.path_manager.download_dir
+        self.jdownloader_download_dir = manager.config_manager.settings_data['Runtime_Options']['jdownloader_download_dir']
+        self.jdownloader_autostart = manager.config_manager.settings_data['Runtime_Options']['jdownloader_autostart']
+        if not self.jdownloader_download_dir:
+            self.jdownloader_download_dir = manager.path_manager.download_dir
+        self.jdownloader_download_dir = Path(self.jdownloader_download_dir)
         self.jdownloader_agent = field(init=False)
 
     async def jdownloader_setup(self) -> None:
         """Setup function for JDownloader"""
         try:
-            if not self.jdownloader_username or not self.jdownloader_password or not self.jdownloader_device:
+            if not all (self.jdownloader_username, self.jdownloader_password, self.jdownloader_device):
                 raise JDownloaderFailure("JDownloader credentials were not provided.")
             jd = myjdapi.Myjdapi()
             jd.set_app_key("CYBERDROP-DL")
             jd.connect(self.jdownloader_username, self.jdownloader_password)
             self.jdownloader_agent = jd.get_device(self.jdownloader_device)
+            return
+
         except (myjdapi.MYJDApiException, JDownloaderFailure) as e:
-            await log("Failed JDownloader setup", 40)
-            await log(e.message, 40)
-            self.enabled = False
-            time.sleep(20)
+            msg = e.message
+
         except myjdapi.MYJDDeviceNotFoundException as e:
-            await log("Failed JDownloader setup", 40)
-            await log(str(e), 40)
-            self.enabled = False
-            time.sleep(20)
+            msg = str(e)
+
+        await log(f"Failed JDownloader setup\n{msg}", 40)
+        self.enabled = False
+        time.sleep(20)
 
     async def direct_unsupported_to_jdownloader(self, url: URL, title: str) -> None:
         """Sends links to JDownloader"""
@@ -51,13 +57,12 @@ class JDownloader:
             assert url.host is not None
             assert self.jdownloader_agent is not None
             self.jdownloader_agent.linkgrabber.add_links([{
-                "autostart": False,
+                "autostart": self.jdownloader_autostart ,
                 "links": str(url),
                 "packageName": title if title else "Cyberdrop-DL",
-                "destinationFolder": str(self.download_directory.absolute()),
+                "destinationFolder": str(self.jdownloader_download_dir.resolve()),
                 "overwritePackagizerRules": True
             }])
 
         except (JDownloaderFailure, AssertionError) as e:
-            await log(f"Failed to send {url} to JDownloader", 40)
-            await log(e.message, 40)
+            await log(f"Failed to send {url} to JDownloader\n{e.message}", 40)

--- a/cyberdrop_dl/scraper/jdownloader.py
+++ b/cyberdrop_dl/scraper/jdownloader.py
@@ -41,11 +41,14 @@ class JDownloader:
             self.jdownloader_agent = jd.get_device(self.jdownloader_device)
             return
 
-        except (myjdapi.MYJDApiException, JDownloaderFailure) as e:
+        except JDownloaderFailure as e:
             msg = e.message
 
-        except myjdapi.MYJDDeviceNotFoundException as e:
+        except myjdapi.MYJDDeviceNotFoundException:
             msg = f"Device not found ({self.jdownloader_device})"
+
+        except myjdapi.MYJDApiException as e:
+            msg = e
 
         await log(f"Failed JDownloader setup: {msg}", 40)
         self.enabled = False
@@ -66,6 +69,5 @@ class JDownloader:
                 "destinationFolder": str(download_folder.resolve()),
                 "overwritePackagizerRules": True
             }])
-
-        except (JDownloaderFailure, AssertionError) as e:
-            await log(f"Failed to send {url} to JDownloader\n{e.message}", 40)
+        except (AssertionError, myjdapi.MYJDApiException) as e:
+            raise JDownloaderFailure(e) 

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -491,6 +491,7 @@ class ScrapeMapper:
                 download_folder = await get_download_path(self.manager, scrape_item, "no_crawler")
                 relative_download_dir = download_folder.relative_to(self.manager.path_manager.download_dir)
                 await self.jdownloader.direct_unsupported_to_jdownloader(scrape_item.url, scrape_item.parent_title, relative_download_dir)
+                await self.manager.progress_manager.scrape_stats_progress.add_unsupported(sent_to_jdownloader=True)
             except JDownloaderFailure as e:
                 await log(f"Failed to send {scrape_item.url} to JDownloader", 40)
                 await log(e.message, 40)
@@ -499,6 +500,7 @@ class ScrapeMapper:
         else:
             await log(f"Unsupported URL: {scrape_item.url}", 30)
             await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url, scrape_item.parents[0] if scrape_item.parents else None)
+            await self.manager.progress_manager.scrape_stats_progress.add_unsupported()
 
     async def filter_items(self, scrape_item: ScrapeItem) -> None:
         """Maps URLs to their respective handlers"""

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -487,15 +487,16 @@ class ScrapeMapper:
 
         elif self.jdownloader.enabled and jdownloader_whitelisted:
             await log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 10)
+            success = False
             try:
-                download_folder = await get_download_path(self.manager, scrape_item, "no_crawler")
+                download_folder = await get_download_path(self.manager, scrape_item, "jdownloader")
                 relative_download_dir = download_folder.relative_to(self.manager.path_manager.download_dir)
                 await self.jdownloader.direct_unsupported_to_jdownloader(scrape_item.url, scrape_item.parent_title, relative_download_dir)
-                await self.manager.progress_manager.scrape_stats_progress.add_unsupported(sent_to_jdownloader=True)
+                success = True
             except JDownloaderFailure as e:
-                await log(f"Failed to send {scrape_item.url} to JDownloader", 40)
-                await log(e.message, 40)
+                await log(f"Failed to send {scrape_item.url} to JDownloader\n{e.message}", 40)
                 await self.manager.log_manager.write_unsupported_urls_log(scrape_item.url, scrape_item.parents[0] if scrape_item.parents else None)
+            await self.manager.progress_manager.scrape_stats_progress.add_unsupported(sent_to_jdownloader=success)
 
         else:
             await log(f"Unsupported URL: {scrape_item.url}", 30)

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -488,7 +488,9 @@ class ScrapeMapper:
         elif self.jdownloader.enabled and jdownloader_whitelisted:
             await log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 10)
             try:
-                await self.jdownloader.direct_unsupported_to_jdownloader(scrape_item.url, scrape_item.parent_title)
+                download_folder = await get_download_path(self.manager, scrape_item, "no_crawler")
+                relative_download_dir = download_folder.relative_to(self.manager.path_manager.download_dir)
+                await self.jdownloader.direct_unsupported_to_jdownloader(scrape_item.url, scrape_item.parent_title, relative_download_dir)
             except JDownloaderFailure as e:
                 await log(f"Failed to send {scrape_item.url} to JDownloader", 40)
                 await log(e.message, 40)

--- a/cyberdrop_dl/ui/progress/statistic_progress.py
+++ b/cyberdrop_dl/ui/progress/statistic_progress.py
@@ -60,6 +60,9 @@ class ScrapeStatsProgress:
 
         self.failure_types: Dict[str, TaskID] = {}
         self.failed_files = 0
+        self.unsupported_urls = 0
+        self.sent_to_jdownloader = 0
+        self.unsupported_urls_skipped = 0
 
     async def get_progress(self) -> Panel:
         """Returns the progress bar"""
@@ -82,6 +85,14 @@ class ScrapeStatsProgress:
             self.failure_types[failure_type] = self.progress.add_task(failure_type, total=self.failed_files,
                                                                     completed=1)
         await self.update_total(self.failed_files)
+
+    async def add_unsupported(self, sent_to_jdownloader: bool = False) -> None:
+        """Adds an unsupported url to the progress bar"""
+        self.unsupported_urls += 1
+        if sent_to_jdownloader:
+            self.sent_to_jdownloader += 1
+        else:
+            self.unsupported_urls_skipped += 1
 
     async def return_totals(self) -> Dict:
         """Returns the total number of failed sites and reasons"""

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -103,8 +103,10 @@ settings: Dict = {
         "skip_check_for_partial_files": False,
         "skip_check_for_empty_folders": False,
         "delete_partial_files": False,
-        "send_unsupported_to_jdownloader": False,
         "update_last_forum_post": True,
+        "send_unsupported_to_jdownloader": False,
+        "jdownloader_download_dir": None,
+        "jdownloader_autostart" : False,
     },
     "Sorting": {
         "sort_downloads": False,

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -107,6 +107,7 @@ settings: Dict = {
         "send_unsupported_to_jdownloader": False,
         "jdownloader_download_dir": None,
         "jdownloader_autostart" : False,
+        "jdownloader_whitelist" : []
     },
     "Sorting": {
         "sort_downloads": False,


### PR DESCRIPTION
1. Add option to autostart downloads on jdownloader as soon as they are sent from CDL
2. Add option to set a `download_dir` for jdownloader, diferent from CDL's. Useful if jdownloader is running on a diferent machine or inside docker
4. Now jdownloader will use the same download path that CDL would have used, instead of downloading all the files in the same folder. This path will be relative to `download_dir`
4. Add whitelist domain filter for jdownloader. Only domains in the whitelist will be sent. Any other URL will just be saved to `unsupported_URLs.txt`. An empty whitelist means `any domain` (every unsupported URL will be sent to jdownloader)
5. Show unsupported URLs stats at the end