### PR TITLE
feat: add integration of Real Debrid

### DIFF
--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -104,9 +104,6 @@ class DownloadClient:
 
         await asyncio.sleep(self.client_manager.download_delay)
 
-        if domain == 'real-debrid' and not media_item.debrid_link:
-            media_item.debrid_link = await manager.real_debrid_manager.unrestrict_link(media_item.url)
-
         download_url = media_item.debrid_link or media_item.url
         async with client_session.get(download_url, headers=download_headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy) as resp:

--- a/cyberdrop_dl/clients/download_client.py
+++ b/cyberdrop_dl/clients/download_client.py
@@ -104,7 +104,11 @@ class DownloadClient:
 
         await asyncio.sleep(self.client_manager.download_delay)
 
-        async with client_session.get(media_item.url, headers=download_headers, ssl=self.client_manager.ssl_context,
+        if domain == 'real-debrid' and not media_item.debrid_link:
+            media_item.debrid_link = await manager.real_debrid_manager.unrestrict_link(media_item.url)
+
+        download_url = media_item.debrid_link or media_item.url
+        async with client_session.get(download_url, headers=download_headers, ssl=self.client_manager.ssl_context,
                                     proxy=self.client_manager.proxy) as resp:
             if resp.status == HTTPStatus.REQUESTED_RANGE_NOT_SATISFIABLE:
                 media_item.partial_file.unlink()

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -11,6 +11,7 @@ from cyberdrop_dl.managers.config_manager import ConfigManager
 from cyberdrop_dl.managers.console_manager import ConsoleManager
 from cyberdrop_dl.managers.db_manager import DBManager
 from cyberdrop_dl.managers.download_manager import DownloadManager
+from cyberdrop_dl.managers.realdebrid_manager import RealDebridManager
 from cyberdrop_dl.managers.hash_manager import HashManager
 from cyberdrop_dl.managers.live_manager import LiveManager
 from cyberdrop_dl.managers.log_manager import LogManager
@@ -29,6 +30,7 @@ class Manager:
         self.path_manager: PathManager = field(init=False)
         self.config_manager: ConfigManager = field(init=False)
         self.hash_manager: HashManager = field(init=False)
+        self.real_debrid_manager: RealDebridManager = field(init=False)
 
         self.log_manager: LogManager = field(init=False)
         self.db_manager: DBManager = field(init=False)

--- a/cyberdrop_dl/managers/manager.py
+++ b/cyberdrop_dl/managers/manager.py
@@ -112,6 +112,8 @@ class Manager:
             await self.hash_manager.startup()
         if not isinstance(self.live_manager, LiveManager):
             self.live_manager = LiveManager(self)
+        if not isinstance(self.real_debrid_manager, RealDebridManager):
+            self.real_debrid_manager = RealDebridManager(self)
         if not isinstance(self.console_manager, ConsoleManager):
             self.console_manager = ConsoleManager()
             self.console_manager.startup()

--- a/cyberdrop_dl/managers/real_debrid/api.py
+++ b/cyberdrop_dl/managers/real_debrid/api.py
@@ -177,11 +177,17 @@ class Unrestrict:
 
     def link(self, link: URL, password: Optional[str] = None, remote: bool=None) -> dict:
         """Unrestrict a hoster link and get a new unrestricted link"""
-        return self.api.post('unrestrict/link', link=link, password=password, remote=remote)
+        JSONResp = self.api.post('unrestrict/link', link=link, password=password, remote=remote)
+        if self.api._convert_special_types:
+            JSONResp['download'] = URL(JSONResp['download'] )
+        return JSONResp
     
     def folder(self, link: URL) -> list:
         """Unrestrict a hoster folder link and get individual links, returns an empty array if no links found"""
-        return self.api.post('unrestrict/folder', link=link)
+        links = self.api.post('unrestrict/folder', link=link)
+        if self.api._convert_special_types:
+            links = [URL(link) for link in links]
+        return links
     
     def container_file(self, filepath: Path) -> dict:
         """Decrypt a container file (RSDF, CCF, CCF3, DLC)"""

--- a/cyberdrop_dl/managers/real_debrid/api.py
+++ b/cyberdrop_dl/managers/real_debrid/api.py
@@ -16,6 +16,7 @@ MAGNET_PREFIX = 'magnet:?xt=urn:btih:'
 DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
 DATE_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
 DATE_JSON_FORMAT =  "%Y-%m-%dT%H:%M:%S.%fZ"
+RATE_LIMIT = 250 # per minute
 
 class RealDebridApi:
     """
@@ -33,7 +34,6 @@ class RealDebridApi:
     """
     API_ENTRYPOINT = URL('https://api.real-debrid.com/rest/1.0')
     API_OAUTH_ENTRYPOINT = URL("https://api.real-debrid.com/oauth/v2/")
-    RATE_LIMIT = 250 # per minute
 
     def __init__(self, api_token: Optional[str] = None, convert_special_types: bool= False):
         self._session = Session()
@@ -72,7 +72,7 @@ class RealDebridApi:
         self._api_token = new_token
         self._session.headers.update({'Authorization': f"Bearer {self._api_token}"})
 
-    def handle_response(self, response: Response) -> dict | str | None:
+    def handle_response(self, response: 'Response') -> dict | str | None:
         try:
             response.raise_for_status()
             JSONResp: dict = response.json()
@@ -87,7 +87,7 @@ class RealDebridApi:
         """Context manager to rate limit API requests
         
         Buffer is % of RATE_LIMIT"""
-        actual_rate_limit = self.RATE_LIMIT * ( 1 - buffer)
+        actual_rate_limit = RATE_LIMIT * ( 1 - buffer)
         elapsed = time.time() - self._last_request_time
         wait_time = max(0, (1 / actual_rate_limit ) - elapsed)
         time.sleep(wait_time)  

--- a/cyberdrop_dl/managers/real_debrid/api.py
+++ b/cyberdrop_dl/managers/real_debrid/api.py
@@ -175,7 +175,7 @@ class Unrestrict:
         """Check if a file is downloadable on the concerned hoster. This request does not require authentication"""
         return self.api.post('unrestrict/check', link=link, password=password)
 
-    def link(self, link: URL, password: Optional[str] = None, remote: bool=None) -> dict:
+    def link(self, link: URL, password: Optional[str] = None, remote: bool=False) -> dict:
         """Unrestrict a hoster link and get a new unrestricted link"""
         JSONResp = self.api.post('unrestrict/link', link=link, password=password, remote=remote)
         if self.api._convert_special_types:

--- a/cyberdrop_dl/managers/real_debrid/api.py
+++ b/cyberdrop_dl/managers/real_debrid/api.py
@@ -1,0 +1,358 @@
+from requests import Session
+from pathlib import Path
+from yarl import URL
+from requests.exceptions import RequestException
+from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
+from datetime import date, datetime, timedelta
+import time
+from contextlib import contextmanager
+
+from typing import TYPE_CHECKING, Optional
+
+if TYPE_CHECKING:
+    from requests import Response
+
+MAGNET_PREFIX = 'magnet:?xt=urn:btih:'
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+DATE_ISO_FORMAT = "%Y-%m-%dT%H:%M:%S%z"
+DATE_JSON_FORMAT =  "%Y-%m-%dT%H:%M:%S.%fZ"
+
+class RealDebridApi:
+    """
+    Real-Debrid API Implementation. All methods return their JSON response (if any)
+    
+    For details, visit: https://api.real-debrid.com
+    
+    Unless specified otherwise, all API methods require authentication.
+
+    The API is limited to 250 requests per minute. Use `rate_limiter` content manager to auto limit the requests being made
+
+    Dates are formatted according to the Javascript method `date.toJSON`. 
+    Use `convert_special_types` to convert response values to `datetime.date`, `datetime.datetime`, `datetime.timedelta` and `yarl.URL` when applicable
+
+    """
+    API_ENTRYPOINT = URL('https://api.real-debrid.com/rest/1.0')
+    API_OAUTH_ENTRYPOINT = URL("https://api.real-debrid.com/oauth/v2/")
+    RATE_LIMIT = 250 # per minute
+
+    def __init__(self, api_token: Optional[str] = None, convert_special_types: bool= False):
+        self._session = Session()
+        self._last_request_time = 0
+        self._convert_special_types = convert_special_types
+        self.auth = OAuth(self)
+        self.system = System(self)
+        self.user = User(self)
+        self.unrestrict = Unrestrict(self)
+        self.traffic = Traffic(self)
+        self.streaming = Streaming(self)
+        self.downloads = Downloads(self)
+        self.torrents = Torrents(self)
+        self.hosts = Hosts(self)
+        self.settings = Settings(self)
+        self.update_token(api_token)
+       
+    def get(self, path: str, **query_params):
+        response = self._session.get(self.API_ENTRYPOINT / path , params= query_params)
+        return self.handle_response(response)
+
+    def post(self, path: str, **data):
+        response = self._session.post(self.API_ENTRYPOINT / path, data=data)
+        return self.handle_response(response)
+    
+    def put(self, path:str, filepath: Path, **query_params):
+        with open(filepath, 'rb') as file:
+            response = self._session.put(self.API_ENTRYPOINT / path, data=file, params=query_params)
+        return self.handle_response(response, path)
+
+    def delete(self, path: str):
+        request = self._session.delete(self.API_ENTRYPOINT / path)
+        return self.handle_response(request)
+            
+    def update_token(self, new_token: str) -> None:
+        self._api_token = new_token
+        self._session.headers.update({'Authorization': f"Bearer {self._api_token}"})
+
+    def handle_response(self, response: Response) -> dict | str | None:
+        try:
+            response.raise_for_status()
+            JSONResp: dict = response.json()
+            return JSONResp
+        except RequestException:
+            raise RealDebridError(response)    
+        except AttributeError:
+            return response.text
+    
+    @contextmanager
+    def rate_limiter(self, buffer: float = 0.2):
+        """Context manager to rate limit API requests
+        
+        Buffer is % of RATE_LIMIT"""
+        actual_rate_limit = self.RATE_LIMIT * ( 1 - buffer)
+        elapsed = time.time() - self._last_request_time
+        wait_time = max(0, (1 / actual_rate_limit ) - elapsed)
+        time.sleep(wait_time)  
+        self._last_request_time = time.time() 
+        yield  
+    
+
+class OAuth:
+    '''RealDebrid authentication via OAuth API'''
+
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+        self.api.API_ENTRYPOINT = self.api.API_OAUTH_ENTRYPOINT 
+        self.grant_type = 'http://oauth.net/grant_type/device/1.0'
+
+    def get_devide_code(self,  client_id: str, new_credentials:bool=False) -> dict:
+        """Get authentication data"""
+        JSONResp = self.api.get('/device/code', client_id= client_id, new_credentials=new_credentials)
+        if self.api._convert_special_types:
+            JSONResp['expires_in'] = timedelta(seconds=JSONResp['expires_in'])
+            JSONResp['verification_url'] = URL(JSONResp['verification_url'])
+        return JSONResp
+
+    def get_credentials(self, client_id: str, device_code: str):
+        """Verify authentication data and get credentials"""
+        return self.api.get('/device/credentials', client_id = client_id, code=device_code)
+    
+    def get_token(self, client_id: str, client_secret: str, device_code: str):
+        """Get token from credentials"""
+        JSONResp = self.api.post('/token', client_id= client_id, client_secret=client_secret, code=device_code, grant_type = self.grant_type)
+        if self.api._convert_special_types:
+            JSONResp['expires_in'] = timedelta(seconds=JSONResp['expires_in'])
+        self.api.update_token(JSONResp['access_token'])
+        return JSONResp
+        
+    def get_new_token(self, client_id: str, client_secret: str, refresh_token: str):
+        """Get a new token"""
+        return self.get_token(client_id= client_id, client_secret=client_secret, device_code=refresh_token)
+    
+    def refresh_token(self, client_id: str, client_secret: str, refresh_token: str):
+        """Calls `get_new_token`"""
+        return self.get_new_token(client_id= client_id, client_secret=client_secret, refresh_token=refresh_token)
+
+class System:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+
+    def disable_token(self) -> None:
+        '''Disable current access token, returns 204 HTTP code'''
+        return self.api.get('/disable_access_token')
+
+    def time(self):
+        '''Get server time. This request does not require authentication'''
+        date_str = self.api.get('/time')
+        if self.api._convert_special_types:
+            return datetime.strptime(date_str, DATE_FORMAT)
+        return date_str
+        
+    def iso_time(self):
+        '''Get server time as ISO (with timezone). This request does not require authentication'''
+        date_str = self.api.get('/time/iso')
+        if self.api._convert_special_types:
+            return datetime.strptime(date_str, DATE_ISO_FORMAT)
+        return date_str
+
+class User:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+
+    def get(self) -> dict:
+        '''Returns information about the current user'''
+        JSONResp = self.api.get('/user')
+        if self.api._convert_special_types:
+            JSONResp['avatar'] = URL(JSONResp['avatar'])
+            JSONResp['premium'] = timedelta(seconds=JSONResp['avatar'])
+            JSONResp['avatar'] = URL(JSONResp['avatar'])
+            JSONResp['expiration']  = datetime.strptime(JSONResp['expiration'], "%Y-%m-%dT%H:%M:%S.%fZ")
+        return JSONResp
+
+class Unrestrict:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+
+    def check(self, link: URL, password: Optional[str] =None):
+        """Check if a file is downloadable on the concerned hoster. This request does not require authentication"""
+        return self.api.post('/unrestrict/check', link=link, password=password)
+
+    def link(self, link: URL, password: Optional[str] = None, remote: bool=None) -> dict:
+        """Unrestrict a hoster link and get a new unrestricted link"""
+        return self.api.post('/unrestrict/link', link=link, password=password, remote=remote)
+    
+    def folder(self, link: URL) -> list:
+        """Unrestrict a hoster folder link and get individual links, returns an empty array if no links found"""
+        return self.api.post('/unrestrict/folder', link=link)
+    
+    def container_file(self, filepath: Path) -> dict:
+        """Decrypt a container file (RSDF, CCF, CCF3, DLC)"""
+        return self.api.put('/unrestrict/containerFile', filepath=filepath)
+
+    def container_link(self, link: URL) -> dict:
+        """Decrypt a container file from a link"""
+        return self.api.post('/unrestrict/containerLink', link=link)
+    
+class Traffic:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+
+    def get(self):
+        """Get traffic informations for limited hosters (limits, current usage, extra packages)"""
+        return self.api.get('/traffic')
+
+    def details(self, start: date = None, end: date=None):
+        """Get traffic details on each hoster used during a defined period"""
+        JSONResp = self.api.get('/traffic/details', start=start, end=end) 
+        if self.api._convert_special_types:
+            JSONResp = {datetime.strptime(key, "%Y-%m-%d").date(): value
+            for key, value in JSONResp.items()}   
+        return JSONResp
+    
+class Streaming:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+
+    def transcode(self, id: str):
+        """Get transcoding links for given file, {id} from /downloads or /unrestrict/link"""
+        return self.api.get(f"/streaming/transcode/{id}")
+
+    def media_info(self, id: str):
+        """Get detailed media information for the given file id, {id} from /downloads or /unrestrict/link"""
+        return self.api.get(f"/streaming/mediaInfos/{id}")
+    
+class Downloads:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+
+    def get(self, offset: int =None, page: int=None, limit:int=None ):
+        """Get user downloads list"""
+        JSONResp = self.api.get('/downloads', offset=offset, page=page, limit=limit)
+        if self.api._convert_special_types:
+            for download in JSONResp:
+                download['generated'] = datetime.strptime(download['generated'], DATE_JSON_FORMAT)
+        return JSONResp
+
+    def delete(self, id: str):
+        """Delete a link from downloads list, returns 204 HTTP code"""
+        return self.api.delete(f'/downloads/delete/{id}')
+
+class Torrents:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+        self.POSIBLE_STATUS = ['magnet_error', 'magnet_conversion', 'waiting_files_selection', 'queued', 'downloading', 'downloaded', 'error', 'virus', 'compressing', 'uploading', 'dead']
+
+    def get(self, offset:int=None, page:int=None, limit:int=None, filter: str=None ):
+        """Get user torrents list"""
+        JSONResp: list[dict] = self.api.get('/torrents', offset=offset, page=page, limit=limit, filter=filter)
+        if self.api._convert_special_types:
+            for torrent in JSONResp:
+                torrent['added'] = datetime.strptime(torrent['added'], DATE_JSON_FORMAT)
+                if torrent.get('ended'):
+                    torrent['ended'] = datetime.strptime(torrent['ended'], DATE_JSON_FORMAT)
+            
+        return JSONResp
+
+    def info(self, id:str):
+        """Get all informations on the asked torrent"""
+        JSONResp: list[dict] = self.api.get(f'/torrents/info/{id}')
+        if self.api._convert_special_types:
+            for torrent in JSONResp:
+                torrent['added'] = datetime.strptime(torrent['added'], DATE_JSON_FORMAT)
+                if torrent.get('ended'):
+                    torrent['ended'] = datetime.strptime(torrent['ended'], DATE_JSON_FORMAT)
+            
+        return JSONResp
+
+    def instant_availability(self, *hash: str):
+        """
+        Get list of instantly available file IDs by hoster, {hash} is the SHA1 of the torrent.
+        You can test multiple hashes adding multiple /{hash} at the end of the request"""
+        return self.api.get('/torrents/instantAvailability/' + "/".join(*hash))
+
+    def active_count(self):
+        """Get currently active torrents number and the current maximum limit"""
+        return self.api.get('/torrents/activeCount')
+    
+    def available_hosts(self):
+        """Get available hosts to upload the torrent to"""
+        return self.api.get('/torrents/availableHosts')
+
+    def add_file(self, filepath:Path, host:Optional[str]=None):
+        """Add a torrent file to download, return a 201 HTTP code"""
+        return self.api.put('/torrents/addTorrent', filepath=filepath, host=host)
+    
+    def add_magnet(self, magnet:str, host:Optional[str]=None):
+        """Add a magnet link to download, returns a 201 HTTP code"""
+        if MAGNET_PREFIX not in magnet:
+            magnet = f"{MAGNET_PREFIX}{magnet}"
+        return self.api.post('/torrents/addMagnet', magnet=magnet, host=host)
+    
+    def select_files(self, id:str, *files:str):
+        """Select files of a torrent to start it, returns 204 HTTP code
+        
+        files =	Selected files IDs (comma separated) or 'all'"""
+        return self.api.post(f'/torrents/selectFiles/{id}', files=','.join(files))
+    
+    def delete(self, id:str):
+        """Delete a torrent from torrents list, returns 204 HTTP code"""
+        return self.api.delete(f'/torrents/delete/{id}')
+
+class Hosts:
+    def __init__(self, api:RealDebridApi):
+        self.api = api
+
+    def get(self):
+        """Get supported hosts. This request does not require authentication"""
+        return self.api.get('/hosts')        
+    
+    def status(self):
+        """Get status of supported hosters or not and their status on competitors"""
+        JSONResp: dict[dict] = self.api.get('/hosts/status')   
+        if self.api._convert_special_types:
+            for host in JSONResp:
+                host['check_time'] = datetime.strptime(host['check_time'], DATE_JSON_FORMAT)
+                if host.get('competitor_status'):
+                    for competitor in host['competitor_status']:
+                        competitor['check_time'] = datetime.strptime(competitor['check_time'], DATE_JSON_FORMAT)
+            
+        return JSONResp
+
+    def regex(self) -> list:
+        """Get all supported links Regex, useful to find supported links inside a document. This request does not require authentication"""
+        return self.api.get('/hosts/regex')  
+
+    def regex_folder(self) -> list:
+        """Get all supported folder Regex, useful to find supported links inside a document. This request does not require authentication"""
+        return self.api.get('/hosts/regexFolder')  
+
+    def domains(self):
+        """Get all hoster domains supported on the service. This request does not require authentication"""
+        return self.api.get('/hosts/domains')  
+
+class Settings:
+    def __init__(self, api: RealDebridApi):
+        self.api = api
+
+    def get(self):
+        """Get current user settings with possible values to update"""
+        return self.api.get('/settings')
+    
+    def update(self, setting_name: str, setting_value:str):
+        """Update a user setting, returns 204 HTTP code"""
+        return self.api.post('/settings/update', setting_name=setting_name, setting_value=setting_value)
+    
+    def convert_points(self):
+        """Convert fidelity points, returns 204 HTTP code"""
+        return self.api.post('/settings/convertPoints')            
+
+    def change_password(self):
+        """Send the verification email to change the password, returns 204 HTTP code"""
+        return self.api.post('/settings/changePassword')      
+
+    def avatar_file(self, filepath:Path):
+        """Upload a new user avatar image, returns 204 HTTP code"""
+        return self.api.put('/settings/avatarFile', filepath=filepath)
+    
+    def avatar_delete(self):
+        """Reset user avatar image to default, returns 204 HTTP code"""
+        return self.api.delete('/settings/avatarDelete')
+

--- a/cyberdrop_dl/managers/real_debrid/api.py
+++ b/cyberdrop_dl/managers/real_debrid/api.py
@@ -51,20 +51,20 @@ class RealDebridApi:
         self.settings = Settings(self)
         self.update_token(api_token)
        
-    def get(self, path: str, /, entrypoint: URL = API_ENTRYPOINT, **query_params):
+    def get(self, path: str, *, entrypoint: URL = API_ENTRYPOINT, **query_params):
         response = self._session.get(url = entrypoint / path, params= query_params)
         return self.handle_response(response)
 
-    def post(self, path: str, /, entrypoint: URL = API_ENTRYPOINT, **data):
+    def post(self, path: str, *, entrypoint: URL = API_ENTRYPOINT, **data):
         response = self._session.post(entrypoint / path, data=data)
         return self.handle_response(response)
     
-    def put(self, path:str, filepath: Path, /,  entrypoint: URL = API_ENTRYPOINT, **query_params):
+    def put(self, path:str, filepath: Path, *,  entrypoint: URL = API_ENTRYPOINT, **query_params):
         with open(filepath, 'rb') as file:
             response = self._session.put(entrypoint/ path, data=file, params=query_params)
         return self.handle_response(response, path)
 
-    def delete(self, path: str, /, entrypoint: URL = API_ENTRYPOINT):
+    def delete(self, path: str, *, entrypoint: URL = API_ENTRYPOINT):
         request = self._session.delete(entrypoint / path)
         return self.handle_response(request)
             

--- a/cyberdrop_dl/managers/real_debrid/errors.py
+++ b/cyberdrop_dl/managers/real_debrid/errors.py
@@ -52,6 +52,8 @@ class RealDebridError(BaseException):
         try:
             JSONResp: dict = response.json()
             self.code = JSONResp.get('error_code')
+            if self.code == 16:
+                self.code = 7
             self.error = ERROR_CODES.get(self.code, 'Unknown error')
             
         except AttributeError:

--- a/cyberdrop_dl/managers/real_debrid/errors.py
+++ b/cyberdrop_dl/managers/real_debrid/errors.py
@@ -47,7 +47,7 @@ ERROR_CODES = {
 
 class RealDebridError(BaseException):
     """Base RealDebrid API error"""
-    def __init__(self, response: Response):
+    def __init__(self, response: 'Response'):
         self.path = URL(response.url).path
         try:
             JSONResp: dict = response.json()

--- a/cyberdrop_dl/managers/real_debrid/errors.py
+++ b/cyberdrop_dl/managers/real_debrid/errors.py
@@ -1,0 +1,62 @@
+from typing import TYPE_CHECKING   
+from http import HTTPStatus
+from yarl import URL
+
+if TYPE_CHECKING:
+    from requests import Response
+    
+ERROR_CODES = {
+    -1: "Internal error",
+    1: "Missing parameter",
+    2: "Bad parameter value",
+    3: "Unknown method",
+    4: "Method not allowed",
+    5: "Slow down",
+    6: "Ressource unreachable",
+    7: "Resource not found",
+    8: "Bad token",
+    9: "Permission denied",
+    10: "Two-Factor authentication needed",
+    11: "Two-Factor authentication pending",
+    12: "Invalid login",
+    13: "Invalid password",
+    14: "Account locked",
+    15: "Account not activated",
+    16: "Unsupported hoster",
+    17: "Hoster in maintenance",
+    18: "Hoster limit reached",
+    19: "Hoster temporarily unavailable",
+    20: "Hoster not available for free users",
+    21: "Too many active downloads",
+    22: "IP Address not allowed",
+    23: "Traffic exhausted",
+    24: "File unavailable",
+    25: "Service unavailable",
+    26: "Upload too big",
+    27: "Upload error",
+    28: "File not allowed",
+    29: "Torrent too big",
+    30: "Torrent file invalid",
+    31: "Action already done",
+    32: "Image resolution error",
+    33: "Torrent already active",
+    34: "Too many requests",
+    35: "Infringing file",
+    36: "Fair Usage Limit"
+}
+
+class RealDebridError(BaseException):
+    """Base RealDebrid API error"""
+    def __init__(self, response: Response):
+        self.path = URL(response.url).path
+        try:
+            JSONResp: dict = response.json()
+            self.code = JSONResp.get('error_code')
+            self.error = ERROR_CODES.get(self.code, 'Unknown error')
+            
+        except AttributeError:
+            self.code = response.status_code
+            self.error = f"{self.code} - {HTTPStatus(self.code).phrase}"
+            
+        self.msg = f'{self.code}: {self.error} at {self.path}'
+        super().__init__(self.msg)

--- a/cyberdrop_dl/managers/realdebrid_manager.py
+++ b/cyberdrop_dl/managers/realdebrid_manager.py
@@ -1,14 +1,14 @@
 from typing import TYPE_CHECKING, Optional
 
-from cyberdrop_dl.managers.real_debrid.api import RealDebridApi
+from cyberdrop_dl.managers.real_debrid.api import RealDebridApi, RATE_LIMIT
 from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
 from cyberdrop_dl.utils.utilities import log
 import re
 from dataclasses import field
+from yarl import URL
+from re import Pattern
 
 if TYPE_CHECKING:
-    from yarl import URL
-    from re import Pattern
     from cyberdrop_dl.managers.manager import Manager
 
 FOLDER_AS_PART = {'folder','folders','dir'}

--- a/cyberdrop_dl/managers/realdebrid_manager.py
+++ b/cyberdrop_dl/managers/realdebrid_manager.py
@@ -57,7 +57,7 @@ class RealDebridManager:
 
     async def is_supported(self, url: URL) -> bool:
         match = self.supported_regex.search(str(url))
-        return bool(match)
+        return bool(match) or 'real-debrid' in url.host.lower()
 
     async def unrestrict_link(self, url: URL, password: Optional[str] = None) -> URL:
         return self.api.unrestrict.link(url, password).get('download')

--- a/cyberdrop_dl/managers/realdebrid_manager.py
+++ b/cyberdrop_dl/managers/realdebrid_manager.py
@@ -1,0 +1,84 @@
+from typing import TYPE_CHECKING, Optional
+
+from cyberdrop_dl.managers.real_debrid.api import RealDebridApi
+from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
+from cyberdrop_dl.utils.utilities import log
+import re
+from dataclasses import field
+
+if TYPE_CHECKING:
+    from yarl import URL
+    from re import Pattern
+    from cyberdrop_dl.managers.manager import Manager
+
+FOLDER_AS_PART = {'folder','folders','dir'}
+FOLDER_AS_QUERY = {'sharekey'}
+
+class RealDebridManager:
+    def __init__(self, manager: 'Manager'):
+        self.manager = manager
+        self.__api_token = self.manager.config_manager.authentication_data['RealDebrid']['realdebrid_api_key']
+        self.enabled = bool(self.__api_token)
+        self.file_regex: Pattern = field(init=False)
+        self.folder_regex: Pattern = field(init=False)
+        self.supported_regex: Pattern = field(init=False)
+        self.api: RealDebridApi = field(init=False)
+        self._folder_guess_functions = [
+            self._guess_folder_by_part, 
+            self._guess_folder_by_query
+            ]
+
+    async def startup(self) -> None:
+        """Startup process for Real Debrid manager"""
+        try:
+            self.api = RealDebridApi(self.__api_token, True)
+            file_regex = "|".join(self.api.hosts.regex())
+            folder_regex = "|".join(self.api.hosts.regex_folder())
+            self.supported_regex = re.compile("|".join(folder_regex + file_regex))
+            self.file_regex = re.compile("|".join(file_regex))
+            self.folder_regex = re.compile("|".join(folder_regex))    
+        except RealDebridError:
+            await log("Failed RealDebrid setup", 40)
+            self.enabled = False  
+
+    async def is_supported_folder(self, url: URL) -> bool:
+        match = self.folder_regex.search(url)
+        return bool(match)
+    
+    async def is_supported_file(self, url: URL) -> bool:
+        match = self.file_regex.search(url)
+        return bool(match)
+
+    async def is_supported(self, url: URL) -> bool:
+        match = self.supported_regex.search(url)
+        return bool(match)
+
+    async def unrestrict_link(self, url: URL, password: Optional[str] = None) -> URL:
+        return self.api.unrestrict.link(url, password).get('download')
+
+    async def unrestrict_folder(self, url: URL) -> list [URL]:
+        return self.api.unrestrict.folder(url)
+    
+    async def _guess_folder_by_part(self, url: URL):
+        folder = None
+        for word in FOLDER_AS_PART:
+            if word in url.parts:
+                index = url.parts.index(word)
+                if index + 1 < len(url.parts):
+                    return url.parts[index + 1]
+        return folder
+        
+    async def _guess_folder_by_query(self, url: URL):
+        for word in FOLDER_AS_QUERY:
+            folder = url.query.get(word)
+            if folder:
+                break
+        return folder
+        
+    async def guess_folder(self, url:URL ) -> str:
+        for guess_function in self._folder_guess_functions:
+            folder = await guess_function(url)
+            if folder:
+                return folder
+        return url.path
+        

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -179,12 +179,13 @@ class Crawler(ABC):
 
     """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""
 
-    async def check_complete_from_referer(self, scrape_item: ScrapeItem) -> bool:
+    async def check_complete_from_referer(self, scrape_item: ScrapeItem| URL) -> bool:
         """Checks if the scrape item has already been scraped"""
+        url = scrape_item if isinstance(scrape_item, URL) else scrape_item.url
         check_complete = await self.manager.db_manager.history_table.check_complete_by_referer(self.domain,
-                                                                                            scrape_item.url)
+                                                                                            url)
         if check_complete:
-            await log(f"Skipping {scrape_item.url} as it has already been downloaded", 10)
+            await log(f"Skipping {url} as it has already been downloaded", 10)
             await self.manager.progress_manager.download_progress.add_previously_completed()
             return True
         return False

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -66,7 +66,7 @@ class Crawler(ABC):
         """Director for scraping"""
         raise NotImplementedError("Must override in child class")
 
-    async def handle_file(self, url: URL, scrape_item: ScrapeItem, filename: str, ext: str, debrid_link: Optional[URL]=None, custom_filename: Optional[str]= None) -> None:
+    async def handle_file(self, url: URL, scrape_item: ScrapeItem, filename: str, ext: str, custom_filename: Optional[str]= None, debrid_link: Optional[URL]=None) -> None:
         """Finishes handling the file and hands it off to the downloader"""
         if custom_filename:
             original_filename, filename = filename , custom_filename

--- a/cyberdrop_dl/scraper/crawler.py
+++ b/cyberdrop_dl/scraper/crawler.py
@@ -66,7 +66,7 @@ class Crawler(ABC):
         """Director for scraping"""
         raise NotImplementedError("Must override in child class")
 
-    async def handle_file(self, url: URL, scrape_item: ScrapeItem, filename: str, ext: str, custom_filename: Optional[str]= None) -> None:
+    async def handle_file(self, url: URL, scrape_item: ScrapeItem, filename: str, ext: str, debrid_link: Optional[URL]=None, custom_filename: Optional[str]= None) -> None:
         """Finishes handling the file and hands it off to the downloader"""
         if custom_filename:
             original_filename, filename = filename , custom_filename
@@ -77,7 +77,7 @@ class Crawler(ABC):
 
         download_folder = await get_download_path(self.manager, scrape_item, self.folder_domain)
         media_item = MediaItem(url, scrape_item.url, scrape_item.album_id, download_folder, filename, ext,
-                            original_filename)
+                            original_filename, debrid_link)
         if scrape_item.possible_datetime:
             media_item.datetime = scrape_item.possible_datetime
 

--- a/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
@@ -39,7 +39,7 @@ class RealDebridCrawler(Crawler):
         scrape_item.album_id = folder_id
         results = await self.get_album_results(folder_id)
 
-        scrape_item.url = self.primary_base_domain / original_url.host.lower() / original_url.path 
+        scrape_item.url = self.primary_base_domain / original_url.host.lower() / original_url.path[1:]
         scrape_item.url = scrape_item.url.with_query(original_url.query).with_fragment(original_url.fragment)
 
         async with self.request_limiter:
@@ -62,7 +62,7 @@ class RealDebridCrawler(Crawler):
         async with self.request_limiter:
             debrid_link = await self.manager.real_debrid_manager.unrestrict_link(original_url, password)
 
-        scrape_item.url = self.primary_base_domain / original_url.host.lower() / original_url.path / debrid_link.name
+        scrape_item.url = self.primary_base_domain / original_url.host.lower() / original_url.path[1:] / debrid_link.name
         scrape_item.url = scrape_item.url.with_query(original_url.query).with_fragment(original_url.fragment)
 
         if await self.check_complete_from_referer(scrape_item):

--- a/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from aiolimiter import AsyncLimiter
+from yarl import URL
+
+from cyberdrop_dl.clients.errors import ScrapeFailure, DownloadFailure, PasswordProtected, NoExtensionFailure
+from cyberdrop_dl.scraper.crawler import Crawler
+from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
+from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+
+if TYPE_CHECKING:
+    from cyberdrop_dl.clients.scraper_client import ScraperClient
+    from cyberdrop_dl.managers.manager import Manager
+
+class RealDebridCrawler(Crawler):
+    def __init__(self, manager: Manager):
+        super().__init__(manager, "real-debrid", "RealDebrid")
+        self.headers = {}
+        self.primary_base_domain = URL('https://real-debrid.com')
+        self.request_limiter = AsyncLimiter(self.manager.real_debrid_manager.api.RATE_LIMIT, 60)
+
+    async def fetch(self, scrape_item: ScrapeItem) -> None:
+        """Determines where to send the scrape item based on the url"""
+        task_id = await self.scraping_progress.add_task(scrape_item.url)
+
+        if await self.manager.real_debrid_manager.is_supported_folder(scrape_item.url):
+            await self.folder(scrape_item)
+        else:
+            await self.file(scrape_item)
+
+        await self.scraping_progress.remove_task(task_id)
+
+    @error_handling_wrapper
+    async def folder(self, scrape_item: ScrapeItem) -> None:
+        """Scrapes a folder"""
+        
+        original_url = scrape_item.url
+        folder_id = await self.manager.real_debrid_manager.guess_folder(original_url)
+        scrape_item.album_id = folder_id
+        results = await self.get_album_results(folder_id)
+
+        scrape_item.url = self.primary_base_domain / original_url.host.lower() / original_url.path 
+        scrape_item.url = scrape_item.url.with_query(original_url.query).with_fragment(original_url.fragment)
+
+        async with self.request_limiter:
+            links = await self.manager.real_debrid_manager.unrestrict_folder(original_url)
+        
+        title = await self.create_title(f"{folder_id} [{original_url.host.lower()}]", None, None)
+        await scrape_item.add_to_parent_title(title)
+
+        for debrid_link in links:
+            link = scrape_item.url / debrid_link.name
+            filename, ext = await get_filename_and_ext(link.name)
+            if not await self.check_album_results(link, results):
+                await self.handle_file(link, scrape_item, filename, ext, debrid_link)
+                
+    @error_handling_wrapper
+    async def file(self, scrape_item: ScrapeItem) -> None:
+        """Scrapes a file"""
+        original_url = scrape_item.url
+        password = original_url.query.get('password','')
+        async with self.request_limiter:
+            debrid_link = await self.manager.real_debrid_manager.unrestrict_link(original_url, password)
+
+        scrape_item.url = self.primary_base_domain / original_url.host.lower() / original_url.path / debrid_link.name
+        scrape_item.url = scrape_item.url.with_query(original_url.query).with_fragment(original_url.fragment)
+
+        if await self.check_complete_from_referer(scrape_item):
+            return
+
+        link = scrape_item.url
+        filename, ext = await get_filename_and_ext(link.name)
+        await self.handle_file(link, scrape_item, filename, ext, debrid_link)
+
+
+
+    """~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"""

--- a/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
@@ -6,7 +6,7 @@ from yarl import URL
 
 from cyberdrop_dl.scraper.crawler import Crawler
 from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
-from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log, log_debug
 from cyberdrop_dl.managers.realdebrid_manager import RATE_LIMIT
 
 if TYPE_CHECKING:
@@ -33,8 +33,8 @@ class RealDebridCrawler(Crawler):
     @error_handling_wrapper
     async def folder(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a folder"""
-        await log ('scraping folder with RealDebrid',10)
         original_url = scrape_item.url
+        await log (f'scraping folder with RealDebrid: {original_url}',10)
         folder_id = await self.manager.real_debrid_manager.guess_folder(original_url)
         scrape_item.album_id = folder_id
         scrape_item.part_of_album = True
@@ -53,24 +53,31 @@ class RealDebridCrawler(Crawler):
     @error_handling_wrapper
     async def file(self, scrape_item: ScrapeItem) -> None:
         """Scrapes a file"""
-        await log ('scraping file with RealDebrid',10)
         original_url = scrape_item.url
         password = original_url.query.get('password','')
         async with self.request_limiter:
             debrid_link = await self.manager.real_debrid_manager.unrestrict_link(original_url, password)
-
-        await log (f"{debrid_link=}",10)
         
         if await self.check_complete_from_referer(scrape_item):
             return
+        
+        await log (f'scraping file with RealDebrid: {original_url}',10)
+        await log_debug(f'original url: {original_url}  -  debrid_url: {debrid_link}',10)
 
         if not scrape_item.part_of_album:
             title = await self.create_title(f"files [{original_url.host.lower()}]", None, None)
             await scrape_item.add_to_parent_title(title)
 
+        # Some hosts use query params or fragment as id or password (ex: mega.nz)
+        # This save the query and fragment as parts of the URL path since DB lookups only use url_path 
         link = self.primary_base_domain / original_url.host.lower() / original_url.path[1:] / debrid_link.name
-        link = scrape_item.url.with_query(original_url.query).with_fragment(original_url.fragment.split('/')[0])
-        await log (f"{link=}",10)
+        if original_url.query:
+            query_params_list = [item for pair in original_url.query.items() for item in pair]
+            link = link / 'query' / "/".join(query_params_list)
+
+        if original_url.fragment:
+            link = link / 'frag'/ original_url.fragment
+
         filename, ext = await get_filename_and_ext(debrid_link.name)
         await self.handle_file(link, scrape_item, filename, ext, debrid_link)
 

--- a/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
+++ b/cyberdrop_dl/scraper/crawlers/realdebrid_crawler.py
@@ -4,13 +4,12 @@ from typing import TYPE_CHECKING
 from aiolimiter import AsyncLimiter
 from yarl import URL
 
-from cyberdrop_dl.clients.errors import ScrapeFailure, DownloadFailure, PasswordProtected, NoExtensionFailure
 from cyberdrop_dl.scraper.crawler import Crawler
 from cyberdrop_dl.utils.dataclasses.url_objects import ScrapeItem
 from cyberdrop_dl.utils.utilities import get_filename_and_ext, error_handling_wrapper, log
+from cyberdrop_dl.managers.realdebrid_manager import RATE_LIMIT
 
 if TYPE_CHECKING:
-    from cyberdrop_dl.clients.scraper_client import ScraperClient
     from cyberdrop_dl.managers.manager import Manager
 
 class RealDebridCrawler(Crawler):
@@ -18,7 +17,7 @@ class RealDebridCrawler(Crawler):
         super().__init__(manager, "real-debrid", "RealDebrid")
         self.headers = {}
         self.primary_base_domain = URL('https://real-debrid.com')
-        self.request_limiter = AsyncLimiter(self.manager.real_debrid_manager.api.RATE_LIMIT, 60)
+        self.request_limiter = AsyncLimiter(RATE_LIMIT, 60)
 
     async def fetch(self, scrape_item: ScrapeItem) -> None:
         """Determines where to send the scrape item based on the url"""

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -498,7 +498,7 @@ class ScrapeMapper:
 
         elif self.manager.real_debrid_manager.enabled and await self.manager.real_debrid_manager.is_supported(scrape_item.url):
             await log(f"Using RealDebrid for unsupported URL: {scrape_item.url}", 10)
-            self.manager.task_group.create_task(self.realdebrid.run(scrape_item))
+            self.manager.task_group.create_task(self.existing_crawlers['realdebrid'].run(scrape_item))
 
         elif self.jdownloader.enabled and jdownloader_whitelisted:
             await log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 10)
@@ -580,7 +580,7 @@ class ScrapeMapper:
 
         elif self.manager.real_debrid_manager.enabled and await self.manager.real_debrid_manager.is_supported(scrape_item.url):
             await log(f"Using RealDebrid for unsupported URL: {scrape_item.url}", 10)
-            self.manager.task_group.create_task(self.realdebrid.run(scrape_item))
+            self.manager.task_group.create_task(self.existing_crawlers['realdebrid'].run(scrape_item))
 
         elif self.jdownloader.enabled:
             await log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 10)

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -470,6 +470,10 @@ class ScrapeMapper:
             self.manager.task_group.create_task(scraper.run(scrape_item))
             return
 
+        elif self.manager.real_debrid_manager.enabled and await self.manager.real_debrid_manager.is_supported(scrape_item.url):
+            await log(f"Using RealDebrid for unsupported URL: {scrape_item.url}", 10)
+            self.manager.task_group.create_task(self.existing_crawlers['realdebrid'].run(scrape_item))
+
         elif await self.extension_check(scrape_item.url):
             check_complete = await self.manager.db_manager.history_table.check_complete("no_crawler", scrape_item.url,
                                                                                         scrape_item.url)
@@ -495,10 +499,6 @@ class ScrapeMapper:
             filename, ext = await get_filename_and_ext(scrape_item.url.name)
             media_item = MediaItem(scrape_item.url, scrape_item.url, None, download_folder, filename, ext, filename)
             self.manager.task_group.create_task(self.no_crawler_downloader.run(media_item))
-
-        elif self.manager.real_debrid_manager.enabled and await self.manager.real_debrid_manager.is_supported(scrape_item.url):
-            await log(f"Using RealDebrid for unsupported URL: {scrape_item.url}", 10)
-            self.manager.task_group.create_task(self.existing_crawlers['realdebrid'].run(scrape_item))
 
         elif self.jdownloader.enabled and jdownloader_whitelisted:
             await log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 10)

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -27,7 +27,7 @@ class ScrapeMapper:
 
     def __init__(self, manager: Manager):
         self.manager = manager
-        self.mapping = {"tokyomotion": self.tokyomotion, "bunkrr": self.bunkrr, "celebforum": self.celebforum, "coomer": self.coomer,
+        self.mapping = {"realdebrid": self.realdebrid, "tokyomotion": self.tokyomotion, "bunkrr": self.bunkrr, "celebforum": self.celebforum, "coomer": self.coomer,
                         "cyberdrop": self.cyberdrop, "cyberfile": self.cyberfile, "e-hentai": self.ehentai,
                         "erome": self.erome, "fapello": self.fapello, "f95zone": self.f95zone, "gofile": self.gofile,
                         "hotpic": self.hotpic, "ibb.co": self.imgbb, "imageban": self.imageban, "imgbox": self.imgbox,
@@ -198,6 +198,11 @@ class ScrapeMapper:
         """Creates a RealBooru Crawler instance"""
         from cyberdrop_dl.scraper.crawlers.realbooru_crawler import RealBooruCrawler
         self.existing_crawlers['realbooru'] = RealBooruCrawler(self.manager)
+
+    async def realdebrid(self) -> None:
+        """Creates a RealDebrid Crawler instance"""
+        from cyberdrop_dl.scraper.crawlers.realdebrid_crawler import RealDebridCrawler
+        self.existing_crawlers['realdebrid'] = RealDebridCrawler(self.manager)
 
     async def reddit(self) -> None:
         """Creates a Reddit Crawler instance"""
@@ -491,6 +496,10 @@ class ScrapeMapper:
             media_item = MediaItem(scrape_item.url, scrape_item.url, None, download_folder, filename, ext, filename)
             self.manager.task_group.create_task(self.no_crawler_downloader.run(media_item))
 
+        elif self.manager.real_debrid_manager.enabled and await self.manager.real_debrid_manager.is_supported(scrape_item.url):
+            await log(f"Using RealDebrid for unsupported URL: {scrape_item.url}", 10)
+            self.manager.task_group.create_task(self.realdebrid.run(scrape_item))
+
         elif self.jdownloader.enabled and jdownloader_whitelisted:
             await log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 10)
             success = False
@@ -568,6 +577,10 @@ class ScrapeMapper:
             filename, ext = await get_filename_and_ext(scrape_item.url.name)
             media_item = MediaItem(scrape_item.url, scrape_item.url, None, download_folder, filename, ext, filename)
             self.manager.task_group.create_task(self.no_crawler_downloader.run(media_item))
+
+        elif self.manager.real_debrid_manager.enabled and await self.manager.real_debrid_manager.is_supported(scrape_item.url):
+            await log(f"Using RealDebrid for unsupported URL: {scrape_item.url}", 10)
+            self.manager.task_group.create_task(self.realdebrid.run(scrape_item))
 
         elif self.jdownloader.enabled:
             await log(f"Sending unsupported URL to JDownloader: {scrape_item.url}", 10)

--- a/cyberdrop_dl/scraper/scraper.py
+++ b/cyberdrop_dl/scraper/scraper.py
@@ -284,12 +284,18 @@ class ScrapeMapper:
         if self.jdownloader.enabled and isinstance(self.jdownloader.jdownloader_agent, Field):
             await self.jdownloader.jdownloader_setup()
 
+    async def start_real_debrid(self) -> None:
+        """Starts RealDebrid"""
+        if self.manager.real_debrid_manager.enabled and isinstance(self.manager.real_debrid_manager.api, Field):
+            await self.manager.real_debrid_manager.startup()
+
     async def start(self) -> None:
         """Starts the orchestra"""
         self.manager.scrape_mapper = self
 
         await self.start_scrapers()
         await self.start_jdownloader()
+        await self.start_real_debrid()
 
         await self.no_crawler_downloader.startup()
 

--- a/cyberdrop_dl/utils/args/config_definitions.py
+++ b/cyberdrop_dl/utils/args/config_definitions.py
@@ -45,6 +45,9 @@ authentication_settings: Dict = {
     "PixelDrain": {
         "pixeldrain_api_key": "",
     },
+    "RealDebrid": {
+        "realdebrid_api_key": "",
+    },
     "Reddit": {
         "reddit_personal_use_script": "",
         "reddit_secret": "",

--- a/cyberdrop_dl/utils/dataclasses/url_objects.py
+++ b/cyberdrop_dl/utils/dataclasses/url_objects.py
@@ -1,6 +1,6 @@
 from dataclasses import field
 from pathlib import Path
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING, Union, Optional
 
 from cyberdrop_dl.utils.utilities import sanitize_folder
 
@@ -11,9 +11,10 @@ if TYPE_CHECKING:
 
 class MediaItem:
     def __init__(self, url: "URL", referer: "URL", album_id: Union[str, None], download_folder: Path, filename: str,
-                ext: str, original_filename: str):
+                ext: str, original_filename: str, debrid_link: Optional['URL'] = None):
         self.url: URL = url
         self.referer: URL = referer
+        self.debrid_link: URL = debrid_link
         self.album_id: Union[str, None] = album_id
         self.download_folder: Path = download_folder
         self.filename: str = filename

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -80,7 +80,7 @@ def error_handling_wrapper(func):
             await self.manager.log_manager.write_unsupported_urls_log(link,parent_url)
             await self.manager.progress_manager.scrape_stats_progress.add_failure("Password Protected")
         except RealDebridError as e:
-            await log(f"Scrape Failed: {link} (RealDebridError)\n{e.error}", 40)
+            await log(f"Scrape Failed: {link} (RealDebridError): {e.error}", 40)
             await self.manager.log_manager.write_scrape_error_log(link, f" {e.error}")
             await self.manager.progress_manager.scrape_stats_progress.add_failure(f"RD - {e.error}")
         except FailedLoginFailure:

--- a/cyberdrop_dl/utils/utilities.py
+++ b/cyberdrop_dl/utils/utilities.py
@@ -14,6 +14,7 @@ from yarl import URL
 
 from cyberdrop_dl.clients.errors import NoExtensionFailure, FailedLoginFailure, InvalidContentTypeFailure, \
     PasswordProtected
+from cyberdrop_dl.managers.real_debrid.errors import RealDebridError
 from cyberdrop_dl.managers.console_manager import log as log_console
 
 if TYPE_CHECKING:
@@ -78,6 +79,10 @@ def error_handling_wrapper(func):
             parent_url = e.scrape_item.parents[0] if e.scrape_item.parents else None
             await self.manager.log_manager.write_unsupported_urls_log(link,parent_url)
             await self.manager.progress_manager.scrape_stats_progress.add_failure("Password Protected")
+        except RealDebridError as e:
+            await log(f"Scrape Failed: {link} (RealDebridError)\n{e.error}", 40)
+            await self.manager.log_manager.write_scrape_error_log(link, f" {e.error}")
+            await self.manager.progress_manager.scrape_stats_progress.add_failure(f"RD - {e.error}")
         except FailedLoginFailure:
             await log(f"Scrape Failed: {link} (Failed Login)", 40)
             await self.manager.log_manager.write_scrape_error_log(link, " Failed Login")


### PR DESCRIPTION
Adds integration to handle URLs supported by [Real Debrid](https://real-debrid.com/)

Real Debrid is a download service which allow the user to download from many file hosters. You send them the URL of the file you want to download, they download the file to their servers and send you back a new URL pointing to their servers so you can download from them in real time, bypassing file hosters restrictions. Most of the time they already have the file cached on their server so the download speed it's max out at your ISP limit.

> [!NOTE]  
> Real Debrid is a paid service

Supported domains include `mega.nz`, `rapidgator`, `1fichier`, `k2s`, etc. List of all supported domains can be found here (250+): https://api.real-debrid.com/rest/1.0/hosts/domains

Implementation is fully functional, currently missing documentation. It's general enough that could be expanded to use different debrid providers in the future by just writing a new api module for them, like all-debrid or premiunize

